### PR TITLE
Prevent submit inside a form.

### DIFF
--- a/src/components/Body.vue
+++ b/src/components/Body.vue
@@ -15,6 +15,7 @@
             <button
               v-for="emoji in group"
               :key="emoji.r"
+              type="button"
               @mouseenter="handleMouseEnter(emoji)"
               @click="handleClick(emoji)"
             >


### PR DESCRIPTION
Prevent submit when emoji picker is used inside a form.

## Context

Currently if picker is embedded in to a form element the undefined buttons submit the form. 
This change will prevent that by adding type="button"

## Summary

Preventing form submission on emoji/group click.

## Relevant Technical Choices

Added `type="button"` to emoji and group buttons.

## Checklist
- [✔] I have tested this code to the best of my abilities
