### PR TITLE
fix:Group names not work #25

### DIFF
--- a/src/components/Body.vue
+++ b/src/components/Body.vue
@@ -9,7 +9,7 @@
           class="v3-group"
         >
           <h5 v-if="hasGroupNames" :class="isSticky ? `v3-sticky` : ``">
-            {{ GROUP_NAMES[key] }}
+            {{ groupNames[key] }}
           </h5>
           <div class="v3-emojis">
             <button


### PR DESCRIPTION
## Context
groups name option not work cause by :used constant data in template


Fixes #25
