### PR TITLE
Fix custom names with group ordering

### DIFF
--- a/src/components/Body.vue
+++ b/src/components/Body.vue
@@ -132,8 +132,6 @@ export default defineComponent({
       }
     )
 
-    console.log(state.orderedGroupKeys)
-
     return {
       emojis,
       bodyInner,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -64,7 +64,7 @@ export default function Store(): Store {
     get orderedGroupKeys() {
       const keys = [
         ...this.options.groupOrder,
-        Object.keys(this.options.additionalGroups),
+        ...Object.keys(this.options.additionalGroups),
         ..._groups.map((group) => group.key),
       ]
       return [...new Set(keys)].filter((key) => !this.disabled.includes(key))


### PR DESCRIPTION
@delowardev This extends the previous PR. While testing this out on our end I think due to store not being reactive I hadn't spotted this bug. However while adding an additional group and also sorting that custom group it was displaying it twice. This PR patches that. 
![image](https://user-images.githubusercontent.com/14275291/199013997-fb7b9a06-4a98-4ca5-b9b8-5d5469bc3567.png)
