### PR TITLE
feat: add lazy loading to emoji image list

### DIFF
--- a/src/components/Body.vue
+++ b/src/components/Body.vue
@@ -26,6 +26,7 @@
                 v-else
                 :src="EMOJI_REMOTE_SRC + `/${emoji.r}.png`"
                 :alt="emoji.n[0]"
+                loading="lazy"
                 @error="handleError($event, emoji.r)"
               />
             </button>


### PR DESCRIPTION
## Context

Improve image loading performance by only loading images that are in view

## Summary

Added `loading="lazy"` to emoji images in body

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Nothing visual changes for the end user

## Checklist

<!-- Check these after PR creation -->

- [x] I have tested this code to the best of my abilities
- [x] I have added documentation where necessary

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #17 
