### PR TITLE
Added support for customising 'recent' group icon

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -101,8 +101,8 @@ export default defineComponent({
         objects,
         symbols,
         flags,
-        ...state.options.groupIcons,
         recent,
+        ...state.options.groupIcons,
       } as Record<string, string>,
     }
   },


### PR DESCRIPTION
## Context

Adding customising options for 'recent' group icon.

## Summary

Because decomposing `state.options.groupIcons` is placed before `recent` field, component prop `group-icons` have no access to change Recent group icon.

## Relevant Technical Choices

By switching those lines it now available to change.

## User-facing changes

In both screenshots to component's code:

```html
<picker :native="false" :display-recent="true" @select="onSelect" :group-icons="{ recent: 'https://www.svgrepo.com/show/172818/star-outline.svg'}" />
```

|Before|After|
|---|---|
| <img width="308" alt="image" src="https://github.com/delowardev/vue3-emoji-picker/assets/44879391/5355bbd7-3a2d-48b9-9553-47ccc0293e94"> | <img width="311" alt="image" src="https://github.com/delowardev/vue3-emoji-picker/assets/44879391/9b4f4112-3f53-44e3-8402-7e764b2f7edb"> |


## Checklist

<!-- Check these after PR creation -->

- [x] I have tested this code to the best of my abilities
- [x] I have added documentation where necessary